### PR TITLE
Implement `PyObject#type`

### DIFF
--- a/lib/pycall/pyobject.rb
+++ b/lib/pycall/pyobject.rb
@@ -135,6 +135,10 @@ module PyCall
     end
 
     alias inspect to_s
+
+    def type
+      LibPython.PyObject_Type(self)
+    end
   end
 
   class PyTypeObject < FFI::Struct

--- a/spec/pycall/pyobject_spec.rb
+++ b/spec/pycall/pyobject_spec.rb
@@ -14,5 +14,11 @@ module PyCall
         expect(PyCall.int(10 * Math::PI)).to eq(31)
       end
     end
+
+    describe '#type' do
+      it 'returns python type' do
+        expect(PyCall::Conversions.from_ruby(1).type.inspect).to eq "pytype(int)"
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit enables us to inspect a type of `PyObject`.
The class of `PyObject` instances are `PyObject`, so we have
no means to inspect types of these instances except checking
type of Python world.