### PR TITLE
Dict: PyObject can be used as keys

### DIFF
--- a/lib/pycall/conversion.rb
+++ b/lib/pycall/conversion.rb
@@ -93,7 +93,7 @@ module PyCall
       case obj
       when LibPython::PyObjectStruct
         obj
-      when PyObject, PyObjectWrapper
+      when PyObjectWrapper
         obj.__pyobj__
       when TrueClass, FalseClass
         LibPython.PyBool_FromLong(obj ? 1 : 0)

--- a/lib/pycall/dict.rb
+++ b/lib/pycall/dict.rb
@@ -21,24 +21,18 @@ module PyCall
 
     def [](key)
       key = key.to_s if key.is_a? Symbol
-      value = if key.is_a? String
-                LibPython.PyDict_GetItemString(__pyobj__, key).to_ruby
-              else
-                LibPython.PyDict_GetItem(__pyobj__, key).to_ruby
-              end
-    ensure
-      case value
-      when LibPython::PyObjectStruct
-        PyCall.incref(value)
-      when PyObjectWrapper
-        PyCall.incref(value.__pyobj__)
+      key = key.__pyobj__ if key.is_a? PyObjectWrapper
+      if key.is_a? String
+        PyCall.incref(LibPython.PyDict_GetItemString(__pyobj__, key)).to_ruby
+      else
+        PyCall.incref(LibPython.PyDict_GetItem(__pyobj__, key)).to_ruby
       end
     end
 
     def []=(key, value)
       key = key.to_s if key.is_a? Symbol
+      key = key.__pyobj__ if key.is_a? PyObjectWrapper
       value = Conversions.from_ruby(value)
-      value = value.__pyobj__ unless value.kind_of? LibPython::PyObjectStruct
       if key.is_a? String
         LibPython.PyDict_SetItemString(__pyobj__, key, value)
       else
@@ -49,6 +43,7 @@ module PyCall
 
     def delete(key)
       key = key.to_s if key.is_a? Symbol
+      key = key.__pyobj__ if key.is_a? PyObjectWrapper
       if key.is_a? String
         value = LibPython.PyDict_GetItemString(__pyobj__, key).to_ruby
         LibPython.PyDict_DelItemString(__pyobj__, key)


### PR DESCRIPTION
I'm trying to write some tensorflow scripts with `pycall` in Ruby now.
I found that it's not possible to use PyObject as python dict key now, so I have to use, for example: `{ x.__pyobj__ => value }` instead of simply `{ x => value }`.

Here's an use case:
https://gist.github.com/bbtfr/5b3e2d20c0d8e7b0d0b716050d7a8217#file-mnist-softmax-rb-L41