### PR TITLE
accept python object as python's hash key

### DIFF
--- a/lib/pycall/dict.rb
+++ b/lib/pycall/dict.rb
@@ -51,6 +51,7 @@ module PyCall
 
     def delete(key)
       key = key.to_s if key.is_a? Symbol
+      key = key.__pyobj__ if key.respond_to?(:__pyobj__)
       if key.is_a? String
         value = LibPython.PyDict_GetItemString(__pyobj__, key).to_ruby
         LibPython.PyDict_DelItemString(__pyobj__, key)

--- a/lib/pycall/dict.rb
+++ b/lib/pycall/dict.rb
@@ -21,6 +21,7 @@ module PyCall
 
     def [](key)
       key = key.to_s if key.is_a? Symbol
+      key = key.__pyobj__ if key.respond_to?(:__pyobj__)
       value = if key.is_a? String
                 LibPython.PyDict_GetItemString(__pyobj__, key).to_ruby
               else

--- a/lib/pycall/dict.rb
+++ b/lib/pycall/dict.rb
@@ -37,6 +37,7 @@ module PyCall
 
     def []=(key, value)
       key = key.to_s if key.is_a? Symbol
+      key = key.__pyobj__ if key.respond_to?(:__pyobj__)
       value = Conversions.from_ruby(value)
       value = value.__pyobj__ unless value.kind_of? LibPython::PyObjectStruct
       if key.is_a? String

--- a/lib/pycall/libpython.rb
+++ b/lib/pycall/libpython.rb
@@ -327,7 +327,7 @@ module PyCall
     attach_function :PyDict_SetItem, [PyObjectStruct.by_ref, PyObjectStruct.by_ref, PyObjectStruct.by_ref], :int
     attach_function :PyDict_SetItemString, [PyObjectStruct.by_ref, :string, PyObjectStruct.by_ref], :int
     attach_function :PyDict_DelItem, [PyObjectStruct.by_ref, PyObjectStruct.by_ref], :int
-    attach_function :PyDict_DelItem, [PyObjectStruct.by_ref, :string], :int
+    attach_function :PyDict_DelItemString, [PyObjectStruct.by_ref, :string], :int
     attach_function :PyDict_Size, [PyObjectStruct.by_ref], :ssize_t
     attach_function :PyDict_Keys, [PyObjectStruct.by_ref], PyObjectStruct.by_ref
     attach_function :PyDict_Values, [PyObjectStruct.by_ref], PyObjectStruct.by_ref

--- a/spec/pycall/dict_spec.rb
+++ b/spec/pycall/dict_spec.rb
@@ -70,6 +70,29 @@ module PyCall
       end
     end
 
+    describe '#delete' do
+      it 'deletes a value for a given key'do
+        expect(subject.delete('a')).to eq(1)
+        expect(subject['b']).to eq(2)
+        expect(subject['c']).to eq(3)
+        expect(subject['a']).to eq(nil)
+      end
+
+      context 'when key is a python object' do
+        let(:key) { mod.time.localtime.() }
+        before do
+          mod.extend PyCall::Import
+          mod.pyimport 'time'
+        end
+        it 'deletes a value for a given key'do
+          expect(subject.delete(key)).to eq(1)
+          expect(subject['b']).to eq(2)
+          expect(subject['c']).to eq(3)
+          expect(subject[key]).to eq(nil)
+        end
+      end
+    end
+
     describe '#has_key?' do
       specify do
         expect(subject).to have_key('a')

--- a/spec/pycall/dict_spec.rb
+++ b/spec/pycall/dict_spec.rb
@@ -5,15 +5,16 @@ module PyCall
   ::RSpec.describe Dict do
     let(:key) { 'a' }
     let(:mod) { Module.new }
+
     subject { Dict.new(key => 1, 'b' => 2, 'c' => 3) }
+
+    before do
+      mod.extend PyCall::Import
+      mod.pyimport 'time'
+    end
 
     describe '.new' do
       let(:key) { mod.time.localtime.() }
-
-      before do
-        mod.extend PyCall::Import
-        mod.pyimport 'time'
-      end
 
       it 'accepts python object as a key' do
         expect{ Dict.new(key => 1) }.not_to raise_error
@@ -36,10 +37,7 @@ module PyCall
 
       context 'when key is a python object' do
         let(:key) { mod.time.localtime.() }
-        before do
-          mod.extend PyCall::Import
-          mod.pyimport 'time'
-        end
+
         it 'returns a value corresponding to a given key' do
           expect(subject[key]).to eq(1)
         end
@@ -57,12 +55,10 @@ module PyCall
         subject['c'] *= 10
         expect(subject['c']).to eq(30)
       end
+
       context 'when key is a python object' do
         let(:key) { mod.time.localtime.() }
-        before do
-          mod.extend PyCall::Import
-          mod.pyimport 'time'
-        end
+
         it 'stores a given value for a given key' do
           subject[key] *= 10
           expect(subject[key]).to eq(10)
@@ -80,10 +76,7 @@ module PyCall
 
       context 'when key is a python object' do
         let(:key) { mod.time.localtime.() }
-        before do
-          mod.extend PyCall::Import
-          mod.pyimport 'time'
-        end
+
         it 'deletes a value for a given key'do
           expect(subject.delete(key)).to eq(1)
           expect(subject['b']).to eq(2)
@@ -100,12 +93,10 @@ module PyCall
         expect(subject).to have_key('c')
         expect(subject).not_to have_key('d')
       end
+
       context 'when key is a python object' do
         let(:key) { mod.time.localtime.() }
-        before do
-          mod.extend PyCall::Import
-          mod.pyimport 'time'
-        end
+
         specify do
           expect(subject).to have_key(key)
           non_key = mod.time.localtime.(mod.time.time.() + 1)

--- a/spec/pycall/dict_spec.rb
+++ b/spec/pycall/dict_spec.rb
@@ -3,10 +3,11 @@ require 'pycall/import'
 
 module PyCall
   ::RSpec.describe Dict do
-    subject { Dict.new('a' => 1, 'b' => 2, 'c' => 3) }
+    let(:key) { 'a' }
+    let(:mod) { Module.new }
+    subject { Dict.new(key => 1, 'b' => 2, 'c' => 3) }
 
     describe '.new' do
-      let(:mod) { Module.new }
       let(:key) { mod.time.localtime.() }
 
       before do
@@ -31,6 +32,17 @@ module PyCall
         pyobj = PyCall.eval('object()')
         subject['o'] = pyobj
         expect { subject['o'] }.to change { pyobj.__pyobj__[:ob_refcnt] }.from(2).to(3)
+      end
+
+      context 'key is a python object' do
+        let(:key) { mod.time.localtime.() }
+        before do
+          mod.extend PyCall::Import
+          mod.pyimport 'time'
+        end
+        it 'returns a value corresponding to a given key' do
+          expect(subject[key]).to eq(1)
+        end
       end
     end
 

--- a/spec/pycall/dict_spec.rb
+++ b/spec/pycall/dict_spec.rb
@@ -34,7 +34,7 @@ module PyCall
         expect { subject['o'] }.to change { pyobj.__pyobj__[:ob_refcnt] }.from(2).to(3)
       end
 
-      context 'key is a python object' do
+      context 'when key is a python object' do
         let(:key) { mod.time.localtime.() }
         before do
           mod.extend PyCall::Import
@@ -57,6 +57,17 @@ module PyCall
         subject['c'] *= 10
         expect(subject['c']).to eq(30)
       end
+      context 'when key is a python object' do
+        let(:key) { mod.time.localtime.() }
+        before do
+          mod.extend PyCall::Import
+          mod.pyimport 'time'
+        end
+        it 'stores a given value for a given key' do
+          subject[key] *= 10
+          expect(subject[key]).to eq(10)
+        end
+      end
     end
 
     describe '#has_key?' do
@@ -65,6 +76,18 @@ module PyCall
         expect(subject).to have_key('b')
         expect(subject).to have_key('c')
         expect(subject).not_to have_key('d')
+      end
+      context 'when key is a python object' do
+        let(:key) { mod.time.localtime.() }
+        before do
+          mod.extend PyCall::Import
+          mod.pyimport 'time'
+        end
+        specify do
+          expect(subject).to have_key(key)
+          non_key = mod.time.localtime.(mod.time.time.() + 1)
+          expect(subject).not_to have_key(non_key)
+        end
       end
     end
   end

--- a/spec/pycall/dict_spec.rb
+++ b/spec/pycall/dict_spec.rb
@@ -1,8 +1,23 @@
 require 'spec_helper'
+require 'pycall/import'
 
 module PyCall
   ::RSpec.describe Dict do
     subject { Dict.new('a' => 1, 'b' => 2, 'c' => 3) }
+
+    describe '.new' do
+      let(:mod) { Module.new }
+      let(:key) { mod.time.localtime.() }
+
+      before do
+        mod.extend PyCall::Import
+        mod.pyimport 'time'
+      end
+
+      it 'accepts python object as a key' do
+        expect{ Dict.new(key => 1) }.not_to raise_error
+      end
+    end
 
     describe '#[]' do
       it 'returns a value corresponding to a given key' do


### PR DESCRIPTION
This pull request is to fix the following error.

I tryed to use tensorflow from pycall like as the following

```
require 'pycall/import'
include PyCall::Import
pyimport "tensorflow", as: :tf

x = tf.placeholder.(tf.float32, shape: PyCall.tuple(nil, 784))
y_ = tf.placeholder.(tf.float32, shape: PyCall.tuple(nil, 10))
...(snip)
result = prediction.eval.(feed_dict: {x => new_img, keep_prob => 1.0}, session: sess)
```

And I got the following error.

```
load ./model.ckpt
        from learn.rb:92:in `<main>'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/pyobject_wrapper.rb:164:in `call'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:12:in `new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:12:in `tap'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:13:in `block in new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:13:in `each'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:14:in `block (2 levels) in new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:40:in `[]='
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/conversion.rb:117:in `from_ruby'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:12:in `new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:12:in `tap'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:13:in `block in new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:13:in `each'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:14:in `block (2 levels) in new'
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:45:in `[]='
        from /home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:45:in `PyDict_SetItem'
/home/suke/.anyenv/envs/rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/pycall-0.1.0.alpha.20170403/lib/pycall/dict.rb:45:in `to_native': wrong argument type PyCall::PyObject (expected PyCall::LibPython::PyObjectStruct) (TypeError)
```

This pull request convert python's hash key to `PyCall::LibPython::PyObjectStruct` before invoking `LibPython.PyDict_SetItem`.
